### PR TITLE
[DO NOT COMMIT] Changes to unblock .glyphs feature compilation

### DIFF
--- a/fea-rs/src/lib.rs
+++ b/fea-rs/src/lib.rs
@@ -14,6 +14,9 @@ mod tests;
 
 pub use compile::Compilation;
 pub use diagnostic::{Diagnostic, Level};
-pub use parse::{parse_root_file, parse_src, FileId, ParseTree, Source, TokenSet};
+pub use parse::{
+    parse_from_memory, parse_root_file, parse_src, FileId, ParseContext, ParseTree, Source,
+    TokenSet,
+};
 pub use token_tree::{typed, Kind, Node, NodeOrToken, Token};
 pub use types::{GlyphIdent, GlyphMap, GlyphName};

--- a/fea-rs/src/parse.rs
+++ b/fea-rs/src/parse.rs
@@ -27,3 +27,11 @@ pub fn parse_root_file(
 ) -> Result<ParseContext, HardError> {
     ParseContext::parse_from_root(path.into(), glyph_map, project_root)
 }
+
+/// Attempt to parse a feature file at a given path, including its imports.
+pub fn parse_from_memory(
+    fea_content: &String,
+    glyph_map: Option<&GlyphMap>,
+) -> Result<ParseContext, HardError> {
+    ParseContext::parse_from_memory(fea_content, glyph_map)
+}


### PR DESCRIPTION
Provided purely for context, changes made locally to unblock .glyphs feature compilation.